### PR TITLE
Improve quote estimator UI and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # APD Marketing
 
-This repository contains sample code for a multi-step quote estimator form which can be embedded in a WordPress site using Elementor. The form is located under the `quote-estimator` directory.
+This repository contains sample code for a multi-step quote estimator form which can be embedded in a WordPress site using Elementor. The form files live inside the `quote-estimator` directory.
+
+## Running Locally
+
+Start a simple web server from the repository root:
+
+```bash
+python3 -m http.server 8080
+```
+
+Visit `http://localhost:8080/quote-estimator/` in your browser to view the estimator. No build steps are required because all dependencies are loaded from CDNs.
+
+## Embedding in WordPress
+
+Upload the files from `quote-estimator` to your theme or include the HTML in an Elementor HTML widget. Ensure `script.js` and `style.css` are referenced correctly relative to your page.

--- a/quote-estimator/index.html
+++ b/quote-estimator/index.html
@@ -16,7 +16,6 @@
     <ul id="progressbar">
       <li class="active">Type</li>
       <li>Size</li>
-      <li>Frame</li>
       <li>Glazing</li>
       <li>Quote</li>
     </ul>
@@ -41,15 +40,6 @@
       </div>
 
       <div class="step" id="step-3">
-        <h2>Select Frame Material</h2>
-        <label><input type="radio" name="frame" value="aluminum" required> Aluminum</label>
-        <label><input type="radio" name="frame" value="wood"> Wood</label>
-        <label><input type="radio" name="frame" value="pvc"> PVC</label>
-        <button type="button" class="prev">Back</button>
-        <button type="button" class="next">Next</button>
-      </div>
-
-      <div class="step" id="step-4">
         <h2>Glazing Options</h2>
         <label><input type="checkbox" name="glazing" value="double"> Double Glazing</label>
         <label><input type="checkbox" name="glazing" value="tinted"> Tinted</label>
@@ -58,7 +48,7 @@
         <button type="button" class="next">Next</button>
       </div>
 
-      <div class="step" id="step-5">
+      <div class="step" id="step-4">
         <h2>Your Quote</h2>
         <div id="quote-summary"></div>
         <input type="hidden" name="quote_details" id="quote-details">

--- a/quote-estimator/script.js
+++ b/quote-estimator/script.js
@@ -61,33 +61,38 @@ $(document).ready(function(){
   function drawWindow(){
     var width = parseFloat($('#width').val()) || 0;
     var height = parseFloat($('#height').val()) || 0;
+    var type = $('#window-type').val();
     if(!width || !height){
       $('#drawing').empty();
       return;
     }
-    var margin = 60;
+    var margin = 80;
+    var glassW = width - 16;
+    var glassH = height - 16;
     var svg = `
       <svg viewBox="0 0 ${width + margin} ${height + margin}" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <linearGradient id="glassGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="rgba(255,255,255,0.5)" />
-            <stop offset="100%" stop-color="rgba(0,150,255,0.25)" />
-          </linearGradient>
-          <linearGradient id="frameGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="#ccc" />
-            <stop offset="100%" stop-color="#666" />
+            <stop offset="0%" stop-color="#b0e0ff" />
+            <stop offset="100%" stop-color="#e6f7ff" />
           </linearGradient>
           <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto">
             <path d="M0,0 L0,6 L9,3 z" fill="#555" />
           </marker>
         </defs>
-        <g transform="translate(30,30)">
-          <rect x="0" y="0" width="${width}" height="${height}" fill="url(#glassGrad)" stroke="url(#frameGrad)" stroke-width="20" />
+        <g transform="translate(40,40)">
+          <rect x="0" y="0" width="${width}" height="${height}" fill="none" stroke="#000" stroke-width="4" />
+          <rect x="4" y="4" width="${width - 8}" height="${height - 8}" fill="none" stroke="#fff" stroke-width="4" />
+          <rect x="8" y="8" width="${glassW}" height="${glassH}" fill="url(#glassGrad)" stroke="#000" stroke-width="4" />
+          ${type === 'awning' ? `<line x1="8" y1="8" x2="${glassW/2 + 8}" y2="${glassH + 8}" stroke="#000" stroke-width="2" />
+          <line x1="${glassW + 8}" y1="8" x2="${glassW/2 + 8}" y2="${glassH + 8}" stroke="#000" stroke-width="2" />` : ''}
+          ${type === 'sliding' ? `<line x1="${glassW/2 + 8}" y1="8" x2="${glassW/2 + 8}" y2="${glassH + 8}" stroke="#000" stroke-width="4" />
+          <line x1="${glassW + 6}" y1="${glassH/2 + 8}" x2="${glassW/2 + 12}" y2="${glassH/2 + 8}" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />` : ''}
         </g>
-        <line x1="30" y1="${height + 40}" x2="${width + 30}" y2="${height + 40}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
-        <text x="${width / 2 + 30}" y="${height + 55}" text-anchor="middle" font-size="14" fill="#555">W ${width}mm</text>
-        <line x1="20" y1="30" x2="20" y2="${height + 30}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
-        <text x="15" y="${height / 2 + 30}" text-anchor="middle" font-size="14" fill="#555" transform="rotate(-90 15,${height / 2 + 30})">H ${height}mm</text>
+        <line x1="40" y1="${height + 60}" x2="${width + 40}" y2="${height + 60}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
+        <text x="${width / 2 + 40}" y="${height + 75}" text-anchor="middle" font-size="14" fill="#555">W ${width}mm</text>
+        <line x1="30" y1="40" x2="30" y2="${height + 40}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
+        <text x="25" y="${height / 2 + 40}" text-anchor="middle" font-size="14" fill="#555" transform="rotate(-90 25,${height / 2 + 40})">H ${height}mm</text>
       </svg>
     `;
 

--- a/quote-estimator/script.js
+++ b/quote-estimator/script.js
@@ -14,10 +14,10 @@ $(document).ready(function(){
     if(validateStep(currentStep)){
       currentStep++;
       showStep(currentStep);
-      if(currentStep === 2 || currentStep === 5){
+      if(currentStep === 2 || currentStep === 4){
         drawWindow();
       }
-      if(currentStep === 5){
+      if(currentStep === 4){
         calculateQuote();
       }
     }
@@ -40,9 +40,6 @@ $(document).ready(function(){
     if(step === 2){
       return $('#width').val() && $('#height').val();
     }
-    if(step === 3){
-      return $('input[name="frame"]:checked').length > 0;
-    }
     return true;
   }
 
@@ -50,14 +47,13 @@ $(document).ready(function(){
     var type = $('#window-type').val();
     var width = parseFloat($('#width').val());
     var height = parseFloat($('#height').val());
-    var area = width * height;
-    var frame = $('input[name="frame"]:checked').val();
+    var frame = 'aluminum';
     var glazing = [];
     $('input[name="glazing"]:checked').each(function(){
       glazing.push($(this).val());
     });
 
-    var summary = \`Type: \${type}<br>Dimensions: \${width}mm x \${height}mm<br>Frame: \${frame}<br>Glazing: \${glazing.join(', ') || 'None'}\`;
+    var summary = `Type: ${type}<br>Dimensions: ${width}mm x ${height}mm<br>Frame: ${frame}<br>Glazing: ${glazing.join(', ') || 'None'}`;
     $('#quote-summary').html(summary);
     $('#quote-details').val(JSON.stringify({ type, width, height, frame, glazing }));
   }
@@ -69,30 +65,37 @@ $(document).ready(function(){
       $('#drawing').empty();
       return;
     }
-    var svg = \`
-      <svg viewBox="0 0 \${width} \${height}" xmlns="http://www.w3.org/2000/svg">
+    var margin = 60;
+    var svg = `
+      <svg viewBox="0 0 ${width + margin} ${height + margin}" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <linearGradient id="glassGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="rgba(255,255,255,0.5)"/>
-            <stop offset="100%" stop-color="rgba(0,150,255,0.25)"/>
+            <stop offset="0%" stop-color="rgba(255,255,255,0.5)" />
+            <stop offset="100%" stop-color="rgba(0,150,255,0.25)" />
           </linearGradient>
           <linearGradient id="frameGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="#ccc"/>
-            <stop offset="100%" stop-color="#666"/>
+            <stop offset="0%" stop-color="#ccc" />
+            <stop offset="100%" stop-color="#666" />
           </linearGradient>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L9,3 z" fill="#555" />
+          </marker>
         </defs>
-        <rect x="0" y="0" width="\${width}" height="\${height}" fill="url(#glassGrad)" stroke="url(#frameGrad)" stroke-width="20"/>
-        <text x="\${width/2}" y="\${height/2}" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#333">\${width} x \${height}</text>
-        <text x="\${width/2}" y="20" text-anchor="middle" class="label-x">\${width}mm</text>
-        <text x="20" y="\${height/2}" text-anchor="middle" class="label-y">\${height}mm</text>
+        <g transform="translate(30,30)">
+          <rect x="0" y="0" width="${width}" height="${height}" fill="url(#glassGrad)" stroke="url(#frameGrad)" stroke-width="20" />
+        </g>
+        <line x1="30" y1="${height + 40}" x2="${width + 30}" y2="${height + 40}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
+        <text x="${width / 2 + 30}" y="${height + 55}" text-anchor="middle" font-size="14" fill="#555">W ${width}mm</text>
+        <line x1="20" y1="30" x2="20" y2="${height + 30}" stroke="#555" marker-start="url(#arrow)" marker-end="url(#arrow)" />
+        <text x="15" y="${height / 2 + 30}" text-anchor="middle" font-size="14" fill="#555" transform="rotate(-90 15,${height / 2 + 30})">H ${height}mm</text>
       </svg>
-    \`;
+    `;
 
     $('#drawing').html(svg);
     $('#drawing svg').hide().fadeIn(300);
   }
 
-  $('#width, #height').on('input', drawWindow);
+  $('#width, #height, #window-type').on('input change', drawWindow);
 
   $('#download-svg').on('click', function() {
     const svg = $('#drawing').html();

--- a/quote-estimator/style.css
+++ b/quote-estimator/style.css
@@ -5,13 +5,31 @@ body {
   padding: 20px;
 }
 .form-container {
-  max-width: 600px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 20px;
+  max-width: 1000px;
   margin: 0 auto;
   background: #fff;
   border: 1px solid #e2e8f0;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
   padding: 20px;
   border-radius: 8px;
+}
+
+#quote-form {
+  flex: 1 1 300px;
+}
+
+#visual-preview {
+  flex: 0 0 300px;
+  position: static;
+  margin-top: 0;
+  background: white;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
 }
 #progressbar {
   display: flex;
@@ -81,14 +99,6 @@ button {
 }
 button:hover {
   background: #007de6;
-}
-#visual-preview {
-  position: sticky;
-  bottom: 0;
-  background: white;
-  padding: 10px;
-  margin-top: 20px;
-  border-top: 1px solid #ccc;
 }
 #drawing {
   background: #f8fafd;


### PR DESCRIPTION
## Summary
- document how to run the estimator locally in README
- remove frame selection step from the form
- place the preview beside the form and tweak styles
- clean script.js, update SVG drawing with measurement arrows

## Testing
- `node --check quote-estimator/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68465ce17cb08331bacbaa646790f17c